### PR TITLE
Features/post pics

### DIFF
--- a/app/controllers/v1/posts_controller.rb
+++ b/app/controllers/v1/posts_controller.rb
@@ -43,7 +43,7 @@ class V1::PostsController < ApplicationController
   private
 
   def permitted_params
-    params.require(:post).permit(:content, :postable)
+    params.require(:post).permit(:content, :postable, pics: [])
   end
 
   def set_postable
@@ -51,7 +51,9 @@ class V1::PostsController < ApplicationController
   end
 
   def post_params
-    { content: permitted_params[:content], postable: set_postable }
+    pics_params = { pics: permitted_params[:pics] }
+    sent_params = { content: permitted_params[:content], postable: set_postable }
+    pics_params[:pics].nil? ? sent_params : sent_params.merge(pics_params)
   end
 
   def set_post

--- a/app/controllers/v1/posts_controller.rb
+++ b/app/controllers/v1/posts_controller.rb
@@ -15,6 +15,9 @@ class V1::PostsController < ApplicationController
 
   def create
     post = pundit_user.authored_posts.build(post_params)
+
+    post.adding_or_purging_pic = true if post_params[:pics]
+
     if post.save
       render :create, locals: { post: post }, status: :created
     else

--- a/app/controllers/v1/posts_controller.rb
+++ b/app/controllers/v1/posts_controller.rb
@@ -26,7 +26,7 @@ class V1::PostsController < ApplicationController
     post = set_post
     authorize_post(post)
 
-    if post&.update(post_params)
+    if post&.modified_update(post_params)
       render :update, locals: { post: post }, status: :accepted
     elsif post
       process_error(post, 'Cannot update post')
@@ -43,7 +43,7 @@ class V1::PostsController < ApplicationController
   private
 
   def permitted_params
-    params.require(:post).permit(:content, :postable, pics: [])
+    params.require(:post).permit(:content, :postable, :purge_pic, pics: [])
   end
 
   def set_postable
@@ -52,8 +52,10 @@ class V1::PostsController < ApplicationController
 
   def post_params
     pics_params = { pics: permitted_params[:pics] }
+    purge_param = { purge_pic: permitted_params[:purge_pic] }
     sent_params = { content: permitted_params[:content], postable: set_postable }
-    pics_params[:pics].nil? ? sent_params : sent_params.merge(pics_params)
+    sent_params = pics_params[:pics].nil? ? sent_params : sent_params.merge(pics_params)
+    purge_param[:purge_pic].nil? ? sent_params : sent_params.merge(purge_param)
   end
 
   def set_post

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,8 @@ module ApplicationHelper
   def convert_to_i(date)
     date.to_time.to_i
   end
+
+  def pic_url(pic)
+    rails_blob_path(pic, only_path: true)
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,6 +7,7 @@ class Post < ApplicationRecord
   belongs_to :author, class_name: 'User'
   has_many :comments, foreign_key: :commentable_id, as: :commentable, dependent: :destroy
   has_many :likes, foreign_key: :likeable_id, as: :likeable, dependent: :destroy
+  has_many_attached :pics, dependent: :purge
 
   scope :order_created, -> { order(created_at: :desc) }
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
-  attr_accessor :postable_param
+  attr_accessor :postable_param, :purge_pic
+  attribute :adding_or_purging_pic, :boolean, default: false
 
   belongs_to :postable, class_name: 'User'
   belongs_to :author, class_name: 'User'
@@ -11,5 +12,18 @@ class Post < ApplicationRecord
 
   scope :order_created, -> { order(created_at: :desc) }
 
-  validates :content, presence: true
+  validates :content, presence: true, unless: :adding_or_purging_pic?
+
+  def modified_update(post_params)
+    if post_params[:purge_pic]
+      purge_id = post_params[:purge_pic]
+      pic = pics.find_by(id: purge_id)
+      pic.purge_later
+      self.adding_or_purging_pic = true
+      save
+    elsif post_params[:pics]
+      self.adding_or_purging_pic = true
+    end
+    update(post_params)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,11 +140,11 @@ class User < ApplicationRecord
 
   # Image uploads related methods
   def ordered_profile_images
-    profile_images.order(created_at: :asc)
+    profile_images.order(created_at: :desc)
   end
 
   def ordered_cover_images
-    cover_images.order(created_at: :asc)
+    cover_images.order(created_at: :desc)
   end
 
   def assign_profile_pic

--- a/app/views/v1/shared/_pic.json.jbuilder
+++ b/app/views/v1/shared/_pic.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.id pic.id
+json.url pic_url(pic)

--- a/app/views/v1/shared/_post.json.jbuilder
+++ b/app/views/v1/shared/_post.json.jbuilder
@@ -28,3 +28,8 @@ json.likes do
 end
 json.liked? pundit_user.liked?(post)
 json.like_id post.like_id(pundit_user)
+json.pics do
+  json.array! post.pics do |pic|
+    json.partial! '/v1/shared/pic', pic: pic
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -58,5 +58,19 @@ RSpec.describe Post, type: :model do
         .with_foreign_key(:likeable_id)
         .dependent(:destroy)
     }
+    it {
+      should have_many(:pics_attachments)
+    }
+    context 'deleting a post with pics' do
+      it 'also deletes associated pics' do
+        post.pics = [pic1, pic2]
+        post.save
+        expect do
+          post.destroy
+        end
+          .to change(ActiveStorage::Attachment, :count)
+          .from(2).to(0)
+      end
+    end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -7,19 +7,39 @@ RSpec.describe Post, type: :model do
   let(:kyle) { create(:user, :male, first_name: 'Kyle') }
   let(:post) { build(:post, author: charlie, postable: kyle) }
   let!(:like) { create(:like, :for_post, likeable: post, liker: kyle) }
+  let!(:pic1) do
+    fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'icy-lake.jpg'), 'image/jpg')
+  end
+  let!(:pic2) do
+    fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'blue-red-lake.jpg'), 'image/jpg')
+  end
+
+  after :all do
+    remove_uploaded_files
+  end
 
   describe 'validation' do
-    context 'content present in post' do
-      it 'is valid' do
-        expect(post).to be_valid
+    context 'adding_or_purging_pic is false' do
+      context 'content present in post' do
+        it 'is valid' do
+          expect(post).to be_valid
+        end
+      end
+
+      context 'post has no content' do
+        it 'is invalid and has errors' do
+          post.content = nil
+          post.valid?
+          expect(post.errors['content']).to be_include("can't be blank")
+        end
       end
     end
 
-    context 'post has no content' do
-      it 'is invalid and has errors' do
+    context 'adding_or_purging_pic is true' do
+      it 'is valid' do
+        post.adding_or_purging_pic = true
         post.content = nil
-        post.valid?
-        expect(post.errors['content']).to be_include("can't be blank")
+        expect(post).to be_valid
       end
     end
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Post, type: :model do
   let(:kyle) { create(:user, :male, first_name: 'Kyle') }
   let(:post) { build(:post, author: charlie, postable: kyle) }
   let!(:like) { create(:like, :for_post, likeable: post, liker: kyle) }
-  let!(:pic1) do
+  let(:pic1) do
     fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'icy-lake.jpg'), 'image/jpg')
   end
-  let!(:pic2) do
+  let(:pic2) do
     fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'blue-red-lake.jpg'), 'image/jpg')
   end
 
@@ -55,6 +55,42 @@ RSpec.describe Post, type: :model do
     context 'user has not liked the post' do
       it 'returns nil' do
         expect(post.like_id(charlie)).to be(nil)
+      end
+    end
+  end
+
+  describe '#modified_update' do
+    context 'adding a pic to a saved post' do
+      before do
+        pics = [pic1]
+        post.save
+        post.modified_update(pics: pics)
+      end
+
+      it 'sets adding_or_purging to true' do
+        expect(post.adding_or_purging_pic).to be(true)
+      end
+
+      it 'updates the post w/ the new pic' do
+        expect(post.pics.count).to be(1)
+        expect(post.pics.first.filename).to eq(pic1.original_filename)
+      end
+    end
+
+    context 'deleting a pic from a saved post' do
+      before do
+        post.pics = [pic1, pic2]
+        post.save
+        purge_id = post.pics.first.id
+        post.modified_update(purge_pic: purge_id)
+      end
+
+      it 'sets adding_or_purging pic to true' do
+        expect(post.adding_or_purging_pic).to be(true)
+      end
+
+      it 'removes the pic from the updated post' do
+        expect(post.pics.count).to be(1)
       end
     end
   end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Posts', type: :request do
   let(:pic1) do
     fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'icy-lake.jpg'), 'image/jpg')
   end
-  let(:pic2) do
+  let!(:pic2) do
     fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'blue-red-lake.jpg'), 'image/jpg')
   end
   let(:post_with_pic) { create(:post, author: beng, postable: beng, pics: [pic1, pic2]) }
@@ -198,7 +198,22 @@ RSpec.describe 'Posts', type: :request do
       end
 
       context 'deleting pic from post' do
-        
+        subject! do
+          put post_route(post_with_pic.id),
+              headers: authorization_header,
+              params: valid_post_attributes(beng, purge_pic: post_with_pic.pics.first.id)
+
+          post_with_pic.reload
+        end
+
+        it 'removes pic from post' do
+          expect(post_with_pic.pics.count).to be(1)
+        end
+
+        it 'sends updated post data as response' do
+          expect(response).to have_http_status(:accepted)
+          expect(json_response['pics'].first['id']).to eq(post_with_pic.pics.first.id)
+        end
       end
     end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'Users', type: :request do
             subject
             alfred.reload
             expect(alfred.profile_pic).to eq(
-              rails_blob_path(alfred.profile_images.last)
+              rails_blob_path(alfred.profile_images.first)
             )
           end
         end
@@ -172,13 +172,13 @@ RSpec.describe 'Users', type: :request do
             update_user(alfred.username, profile_images: [profile_pic2])
             login_as(alfred)
             update_user(alfred.username, profile_pic: rails_blob_path(
-              alfred.ordered_profile_images.first, only_path: true
+              alfred.ordered_profile_images.last, only_path: true
             ))
             alfred.reload
           end
 
           it 'changes profile pic of user' do
-            pic_url = rails_blob_path(alfred.ordered_profile_images.first, only_path: true)
+            pic_url = rails_blob_path(alfred.ordered_profile_images.last, only_path: true)
             expect(alfred.profile_pic).to eq(pic_url)
           end
         end
@@ -198,7 +198,7 @@ RSpec.describe 'Users', type: :request do
             subject
             alfred.reload
             expect(alfred.cover_pic).to eq(
-              rails_blob_path(alfred.cover_images.last, only_path: true)
+              rails_blob_path(alfred.cover_images.first, only_path: true)
             )
           end
         end
@@ -210,14 +210,14 @@ RSpec.describe 'Users', type: :request do
             update_user(alfred.username, cover_images: [cover_pic2])
             login_as(alfred)
             update_user(alfred.username, cover_pic: rails_blob_path(
-              alfred.ordered_cover_images.first, only_path: true
+              alfred.ordered_cover_images.last, only_path: true
             ))
             alfred.reload
           end
 
           it 'changes cover pic for user' do
             pic_url = rails_blob_path(
-              alfred.ordered_cover_images.first, only_path: true
+              alfred.ordered_cover_images.last, only_path: true
             )
             expect(alfred.cover_pic).to eq(pic_url)
           end

--- a/spec/support/response_data.rb
+++ b/spec/support/response_data.rb
@@ -27,7 +27,7 @@ module Helpers
     end
 
     def post_response_keys
-      %w[id content created_at updated_at author posted_to comments likes liked? like_id]
+      %w[id content created_at updated_at author posted_to comments likes liked? like_id pics]
     end
 
     def timeline_posts_response_keys


### PR DESCRIPTION
Adding pictures to posts is the main feature of this PR:

- added `has_many_attached :pics, dependent: :purge` to the `Post` model
- added a `adding_or_purging_pic` (a boolean) and `:purge_pic` attribute (which is necessary in order to have this included in the `post_params`)
- adding a `modified_update` method to `Post` model which will qualify if `post_params` includes either `purge_pic` or `purging_pic` parameters. In which cases the `adding_or_purging_pic` attribute is set to true. In the case of `purging_pic` presence, the particular image (value of the `purging_pic` parameter key) will be deleted from the `post`.
- Modified `_post.json.jbuilder` to include data about each post's pics (if present)
- Created a `_pic.json.jbuilder` partial containing id and url of a post
- Created a `pic_url` helper method to generate url of each pic